### PR TITLE
Move wallsign check to post-house-sign validation

### DIFF
--- a/src/main/java/net/pandette/housepoints/listeners/PointsListener.java
+++ b/src/main/java/net/pandette/housepoints/listeners/PointsListener.java
@@ -69,16 +69,16 @@ public class PointsListener implements Listener {
 
         Sign sign = (Sign) event.getBlock().getState();
 
-        if (!Tag.WALL_SIGNS.isTagged(event.getBlock().getType())) {
-            event.getPlayer().sendMessage(languageHook.getMessage("listener.wallsign", player,
-                    DEFAULT_WALL_SIGN));
-            return;
-        }
-
         Location loc = event.getBlock().getLocation();
         HousePointsModifier modifier = PointsPlugin.getInstance().getHousePointsModifier();
         for (House house : houseManager.getHouses()) {
             if (ChatColor.stripColor(event.getLine(0)).equalsIgnoreCase("[" + house.getName() + "]")) {
+                if (!Tag.WALL_SIGNS.isTagged(event.getBlock().getType())) {
+                    event.getPlayer().sendMessage(languageHook.getMessage("listener.wallsign", player,
+                            DEFAULT_WALL_SIGN));
+                    return;
+                }
+
                 sign.setLine(0, house.getChatColor() + house.getName());
                 sign.setLine(2, String.valueOf(modifier.getPoints(house.getName().toUpperCase())));
                 sign.update();


### PR DESCRIPTION
Previously the check in the house sign creation process concerning the
sign being a wall sign happened prior to actually validating that the
sign is going to be a house point related sign.

This had the effect that players with permission to create house point
signs would be notified with the wall-sign error message whenever
creating a sign that is not a wall sign itself.

To fix this, this commit moves this check after the actually validation
of the signs content to be a house points, therefore only notifying
players about an incorrect sign type if the sign itself is going to be a
house points sign.